### PR TITLE
Remove BindVisitor dependency given it's deprecated in Arel 9.0

### DIFF
--- a/lib/active_record/connection_adapters/odbc_adapter.rb
+++ b/lib/active_record/connection_adapters/odbc_adapter.rb
@@ -1,5 +1,4 @@
 require 'active_record'
-require 'arel/visitors/bind_visitor'
 require 'odbc'
 require 'odbc_utf8'
 

--- a/lib/odbc_adapter/adapters/null_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/null_odbc_adapter.rb
@@ -4,15 +4,13 @@ module ODBCAdapter
     # registry. This allows for minimal support for DBMSs for which we don't
     # have an explicit adapter.
     class NullODBCAdapter < ActiveRecord::ConnectionAdapters::ODBCAdapter
-      class BindSubstitution < Arel::Visitors::ToSql
-        include Arel::Visitors::BindVisitor
-      end
-
       # Using a BindVisitor so that the SQL string gets substituted before it is
       # sent to the DBMS (to attempt to get as much coverage as possible for
       # DBMSs we don't support).
       def arel_visitor
-        BindSubstitution.new(self)
+        # Using PostgresSQL visitor since BindVisitor is deprecated in Arel 9.0
+        # We only need Postgre Adapter.
+        Arel::Visitors::PostgreSQL.new(self)
       end
 
       # Explicitly turning off prepared_statements in the null adapter because

--- a/lib/odbc_adapter/adapters/null_odbc_adapter.rb
+++ b/lib/odbc_adapter/adapters/null_odbc_adapter.rb
@@ -8,8 +8,11 @@ module ODBCAdapter
       # sent to the DBMS (to attempt to get as much coverage as possible for
       # DBMSs we don't support).
       def arel_visitor
-        # Using PostgresSQL visitor since BindVisitor is deprecated in Arel 9.0
-        # We only need Postgre Adapter.
+        # BindVisitor was used to substitude SQL string before it is sent to the
+        # DBMS (to attempt to get as much coverage as possible for DMBSs).
+        #
+        # However, BindVisitor is removed in Arel 9.0, and we only need to support
+        # Postgres; Replace with PostgreSQL visitor for our use case.
         Arel::Visitors::PostgreSQL.new(self)
       end
 

--- a/lib/odbc_adapter/database_statements.rb
+++ b/lib/odbc_adapter/database_statements.rb
@@ -10,7 +10,7 @@ module ODBCAdapter
     def execute(sql, name = nil, binds = [])
       log(sql, name) do
         if prepared_statements
-          @connection.do(sql, *prepared_binds(binds))
+          @connection.do(prepare_statement_sub(sql), *prepared_binds(binds))
         else
           @connection.do(sql)
         end
@@ -24,7 +24,7 @@ module ODBCAdapter
       log(sql, name) do
         stmt =
           if prepared_statements
-            @connection.run(sql, *prepared_binds(binds))
+            @connection.do(prepare_statement_sub(sql), *prepared_binds(binds))
           else
             @connection.run(sql)
           end
@@ -127,8 +127,13 @@ module ODBCAdapter
       col_name == 'id' ? false : result
     end
 
+    # Adapt to Rails 5.2
+    def prepare_statement_sub(sql)
+      sql.gsub(/\$\d+/, '?')
+    end
+
     def prepared_binds(binds)
-      prepare_binds_for_database(binds).map { |bind| _type_cast(bind) }
+      binds.map(&:value_for_database).map { |bind| _type_cast(bind) }
     end
   end
 end


### PR DESCRIPTION
Rails 5.2 requires Arel 9.0, which is what we're at; whereas the gem depends on Arel 8.0.
`arel/visitors/visitor` was removed in Arel 9.0; note that this was required for MySQL adapter only, and we don't need that. Patching this so it can be compatible with our use case. 

This PR is probably not going to be merged; the plan is that cnce the original gem has fixed this, we can pull the original gem instead. Some PR pending in that repo: https://github.com/localytics/odbc_adapter/pull/26

CI failed, seems unrelated 🤔 
```
sql: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
The command "bin/ci-setup" failed and exited with 2 during .
```
I ran the changes locally and it seems to work with core. 